### PR TITLE
Inline and access optimizations for TLorentzVector and TVector3

### DIFF
--- a/math/physics/inc/TLorentzVector.h
+++ b/math/physics/inc/TLorentzVector.h
@@ -64,7 +64,7 @@ public:
    TLorentzVector(const TLorentzVector & lorentzvector);
    // Copy constructor.
 
-   virtual ~TLorentzVector();
+   virtual ~TLorentzVector(){};
    // Destructor
 
    // inline operator TVector3 () const;
@@ -339,9 +339,9 @@ inline void TLorentzVector::SetPxPyPzE(Double_t px, Double_t py, Double_t pz, Do
 }
 
 inline void TLorentzVector::SetXYZM(Double_t  x, Double_t  y, Double_t  z, Double_t m) {
-   if ( m  >= 0 ) 
+   if ( m  >= 0 )
       SetXYZT( x, y, z, TMath::Sqrt(x*x+y*y+z*z+m*m) );
-   else 
+   else
       SetXYZT( x, y, z, TMath::Sqrt( TMath::Max((x*x+y*y+z*z-m*m), 0. ) ) );
 }
 
@@ -365,8 +365,8 @@ inline void TLorentzVector::GetXYZT(Float_t *carray) const{
    carray[3] = fE;
 }
 
-Double_t & TLorentzVector::operator [] (int i)       { return (*this)(i); }
-Double_t   TLorentzVector::operator [] (int i) const { return (*this)(i); }
+inline Double_t & TLorentzVector::operator [] (int i)       { return (*this)(i); }
+inline Double_t   TLorentzVector::operator [] (int i) const { return (*this)(i); }
 
 inline TLorentzVector &TLorentzVector::operator = (const TLorentzVector & q) {
    fP = q.Vect();
@@ -596,5 +596,60 @@ inline TLorentzVector operator * (Double_t a, const TLorentzVector & p) {
    return TLorentzVector(a*p.X(), a*p.Y(), a*p.Z(), a*p.T());
 }
 
+inline TLorentzVector::TLorentzVector()
+               : fP(), fE(0.0) {}
+
+inline TLorentzVector::TLorentzVector(Double_t x, Double_t y, Double_t z, Double_t t)
+               : fP(x,y,z), fE(t) {}
+
+inline TLorentzVector::TLorentzVector(const Double_t * x0)
+               : fP(x0), fE(x0[3]) {}
+
+inline TLorentzVector::TLorentzVector(const Float_t * x0)
+               : fP(x0), fE(x0[3]) {}
+
+inline TLorentzVector::TLorentzVector(const TVector3 & p, Double_t e)
+               : fP(p), fE(e) {}
+
+inline TLorentzVector::TLorentzVector(const TLorentzVector & p) : TObject(p)
+               , fP(p.Vect()), fE(p.T()) {}
+
+
+
+inline Double_t TLorentzVector::operator () (int i) const
+{
+   //dereferencing operator const
+   switch(i) {
+      case kX:
+	 return fP.X();
+      case kY:
+         return fP.Y();
+      case kZ:
+         return fP.Z();
+      case kT:
+         return fE;
+      default:
+         Error("operator()()", "bad index (%d) returning 0",i);
+   }
+   return 0.;
+}
+
+inline Double_t & TLorentzVector::operator () (int i)
+{
+   //dereferencing operator
+   switch(i) {
+      case kX:
+         return fP.fX;
+      case kY:
+         return fP.fY;
+      case kZ:
+         return fP.fZ;
+      case kT:
+         return fE;
+      default:
+         Error("operator()()", "bad index (%d) returning &fE",i);
+   }
+   return fE;
+}
 
 #endif

--- a/math/physics/inc/TVector3.h
+++ b/math/physics/inc/TVector3.h
@@ -20,6 +20,9 @@
 #ifndef ROOT_TMatrix
 #include "TMatrix.h"
 #endif
+#ifndef ROOT_TMath
+#include "TMath.h"
+#endif
 
 class TRotation;
 
@@ -42,7 +45,7 @@ public:
    TVector3(const TVector3 &);
    // The copy constructor.
 
-   virtual ~TVector3();
+   virtual ~TVector3() {};
    // Destructor
 
    Double_t operator () (int) const;
@@ -88,7 +91,7 @@ public:
    inline Double_t Mag2() const;
    // The magnitude squared (rho^2 in spherical coordinate system).
 
-   Double_t Mag() const;
+   Double_t Mag() const { return TMath::Sqrt(Mag2()); }
    // The magnitude (rho in spherical coordinate system).
 
    void SetPhi(Double_t);
@@ -192,8 +195,9 @@ private:
 
    ClassDef(TVector3,3) // A 3D physics vector
 
+   // make TLorentzVector a friend class
+   friend class TLorentzVector;
 };
-
 
 TVector3 operator + (const TVector3 &, const TVector3 &);
 // Addition of 3-vectors.
@@ -211,8 +215,8 @@ TVector3 operator * (Double_t a, const TVector3 &);
 TVector3 operator * (const TMatrix &, const TVector3 &);
 
 
-Double_t & TVector3::operator[] (int i)       { return operator()(i); }
-Double_t   TVector3::operator[] (int i) const { return operator()(i); }
+inline Double_t & TVector3::operator[] (int i)       { return operator()(i); }
+inline Double_t   TVector3::operator[] (int i) const { return operator()(i); }
 
 inline Double_t TVector3::x()  const { return fX; }
 inline Double_t TVector3::y()  const { return fY; }
@@ -246,6 +250,51 @@ inline void TVector3::GetXYZ(Float_t *carray) const {
    carray[2] = fZ;
 }
 
+////////////////////////////////////////////////////////////////////////////////
+/// Constructors
+inline TVector3::TVector3()
+: fX(0.0), fY(0.0), fZ(0.0) {}
+
+inline TVector3::TVector3(const TVector3 & p) : TObject(p),
+  fX(p.fX), fY(p.fY), fZ(p.fZ) {}
+
+inline TVector3::TVector3(Double_t xx, Double_t yy, Double_t zz)
+: fX(xx), fY(yy), fZ(zz) {}
+
+inline TVector3::TVector3(const Double_t * x0)
+: fX(x0[0]), fY(x0[1]), fZ(x0[2]) {}
+
+inline TVector3::TVector3(const Float_t * x0)
+: fX(x0[0]), fY(x0[1]), fZ(x0[2]) {}
+
+
+inline Double_t TVector3::operator () (int i) const {
+   switch(i) {
+      case 0:
+         return fX;
+      case 1:
+         return fY;
+      case 2:
+         return fZ;
+      default:
+         Error("operator()(i)", "bad index (%d) returning 0",i);
+   }
+   return 0.;
+}
+
+inline Double_t & TVector3::operator () (int i) {
+   switch(i) {
+      case 0:
+         return fX;
+      case 1:
+         return fY;
+      case 2:
+         return fZ;
+      default:
+         Error("operator()(i)", "bad index (%d) returning &fX",i);
+   }
+   return fX;
+}
 
 inline TVector3 & TVector3::operator = (const TVector3 & p) {
    fX = p.fX;
@@ -372,5 +421,6 @@ inline TVector2 TVector3::EtaPhiVector() const {
 inline TVector2 TVector3::XYvector() const {
    return TVector2(fX,fY);
 }
+
 
 #endif

--- a/math/physics/src/TLorentzVector.cxx
+++ b/math/physics/src/TLorentzVector.cxx
@@ -5,295 +5,248 @@
 //    Oct 20 1999: dito in Double_t operator()
 //    Jan 25 2000: implemented as (fP,fE) instead of (fX,fY,fZ,fE)
 
-//______________________________________________________________________________
-//*-*-*-*-*-*-*-*-*-*-*-*The Physics Vector package *-*-*-*-*-*-*-*-*-*-*-*
-//*-*                    ==========================                       *
-//*-* The Physics Vector package consists of five classes:                *
-//*-*   - TVector2                                                        *
-//*-*   - TVector3                                                        *
-//*-*   - TRotation                                                       *
-//*-*   - TLorentzVector                                                  *
-//*-*   - TLorentzRotation                                                *
-//*-* It is a combination of CLHEPs Vector package written by             *
-//*-* Leif Lonnblad, Andreas Nilsson and Evgueni Tcherniaev               *
-//*-* and a ROOT package written by Pasha Murat.                          *
-//*-* for CLHEP see:  http://wwwinfo.cern.ch/asd/lhc++/clhep/             *
-//*-* Adaption to ROOT by Peter Malzacher                                 *
-//*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
-//BEGIN_HTML <!--
-/* -->
-<H2>TLorentzVector</H2>
-<TT>TLorentzVector</TT> is a general four-vector class, which can be used
+
+/** \class TLorentzVector
+    \ingroup Physics
+TLorentzVector is a general four-vector class, which can be used
 either for the description of position and time (x,y,z,t) or momentum and
 energy (px,py,pz,E).
-<BR>&nbsp;
-<H3>
-Declaration</H3>
-<TT>TLorentzVector</TT> has been implemented as a set a <TT>TVector3</TT> and a <TT>Double_t</TT> variable.
+
+### Declaration
+TLorentzVector has been implemented as a set a TVector3 and a Double_t variable.
 By default all components are initialized by zero.
 
-<P><TT>&nbsp; TLorentzVector v1;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; // initialized
-by (0., 0., 0., 0.)</TT>
-<BR><TT>&nbsp; TLorentzVector v2(1., 1., 1., 1.);</TT>
-<BR><TT>&nbsp; TLorentzVector v3(v1);</TT>
-<BR><TT>&nbsp; TLorentzVector v4(TVector3(1., 2., 3.),4.);</TT>
+~~~ {.cpp}
+  TLorentzVector v1;      // initialized by (0., 0., 0., 0.)
+  TLorentzVector v2(1., 1., 1., 1.);
+  TLorentzVector v3(v1);
+  TLorentzVector v4(TVector3(1., 2., 3.),4.);
+~~~
 
-<P>For backward compatibility there are two constructors from an <TT>Double_t</TT>
-and <TT>Float_t</TT>&nbsp; C array.
-<BR>&nbsp;
+For backward compatibility there are two constructors from an Double_t
+and Float_t  C array.
 
-<H3>
-Access to the components</H3>
-There are two sets of access functions to the components of a<TT> LorentzVector</TT>:
-<TT>X(</TT>), <TT>Y()</TT>, <TT>Z()</TT>, <TT>T()</TT> and <TT>Px()</TT>,<TT>
-Py()</TT>, <TT>Pz()</TT> and <TT>E()</TT>. Both sets return the same values
-but the first set is more relevant for use where <TT>TLorentzVector</TT>
+
+### Access to the components
+There are two sets of access functions to the components of a LorentzVector:
+X(), Y(), Z(), T() and Px(),
+Py(), Pz() and E(). Both sets return the same values
+but the first set is more relevant for use where TLorentzVector
 describes a combination of position and time and the second set is more
-relevant where <TT>TLorentzVector</TT> describes momentum and energy:
+relevant where TLorentzVector describes momentum and energy:
 
-<P><TT>&nbsp; Double_t xx =v.X();</TT>
-<BR><TT>&nbsp; ...</TT>
-<BR><TT>&nbsp; Double_t tt = v.T();</TT>
+~~~ {.cpp}
+  Double_t xx =v.X();
+  ...
+  Double_t tt = v.T();
 
-<P><TT>&nbsp; Double_t px = v.Px();</TT>
-<BR><TT>&nbsp; ...</TT>
-<BR><TT>&nbsp; Double_t ee = v.E();</TT>
+  Double_t px = v.Px();
+  ...
+  Double_t ee = v.E();
+~~~
 
-<P>The components of TLorentzVector can also accessed by index:
+The components of TLorentzVector can also accessed by index:
 
-<P><TT>&nbsp; xx = v(0);&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; or&nbsp;&nbsp;&nbsp;&nbsp;
-xx = v[0];</TT>
-<BR><TT>&nbsp; yy = v(1);&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-yy = v[1];</TT>
-<BR><TT>&nbsp; zz = v(2);&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-zz = v[2];</TT>
-<BR><TT>&nbsp; tt = v(3);&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-tt = v[3];</TT>
+~~~ {.cpp}
+  xx = v(0);       or     xx = v[0];
+  yy = v(1);              yy = v[1];
+  zz = v(2);              zz = v[2];
+  tt = v(3);              tt = v[3];
+~~~
 
-<P>You can use the <TT>Vect()</TT> member function to get the vector component
-of <TT>TLorentzVector</TT>:
+You can use the Vect() member function to get the vector component
+of TLorentzVector:
 
-<P>&nbsp; <TT>TVector3 p = v.Vect();</TT>
+~~~ {.cpp}
+  TVector3 p = v.Vect();
+~~~
 
-<P>For setting components also two sets of member functions can be used:
-SetX(),.., SetPx(),..:
-<BR>&nbsp;
-<BR><TT>&nbsp; v.SetX(1.);&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; or&nbsp;&nbsp;&nbsp;
-v.SetPx(1.);</TT>
-<BR><TT>&nbsp; ...&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-...</TT>
-<BR><TT>&nbsp; v.SetT(1.);&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-v.SetE(1.);</TT>
+For setting components also two sets of member functions can be used:
 
-<P>To set more the one component by one call you can use the <TT>SetVect()</TT>
-function for the <TT>TVector3</TT> part or <TT>SetXYZT()</TT>, <TT>SetPxPyPzE()</TT>. For convenience there is
+~~~ {.cpp}
+  v.SetX(1.);        or    v.SetPx(1.);
+  ...                               ...
+  v.SetT(1.);              v.SetE(1.);
+~~~
 
-also a <TT>SetXYZM()</TT>:
+To set more the one component by one call you can use the SetVect()
+function for the TVector3 part or SetXYZT(), SetPxPyPzE(). For convenience there is
 
-<P><TT>&nbsp; v.SetVect(TVector3(1,2,3));</TT>
-<BR><TT>&nbsp; v.SetXYZT(x,y,z,t);</TT>
-<BR><TT>&nbsp; v.SetPxPyPzE(px,py,pz,e);</TT>
-<BR><TT>&nbsp; v.SetXYZM(x,y,z,m);&nbsp;&nbsp; //&nbsp;&nbsp; ->&nbsp;
-v=(x,y,z,e=Sqrt(x*x+y*y+z*z+m*m))</TT>
-<H3>
-Vector components in noncartesian coordinate systems</H3>
-There are a couple of memberfunctions to get and set the <TT>TVector3</TT>
+also a SetXYZM():
+
+~~~ {.cpp}
+  v.SetVect(TVector3(1,2,3));
+  v.SetXYZT(x,y,z,t);
+  v.SetPxPyPzE(px,py,pz,e);
+  v.SetXYZM(x,y,z,m);   //   ->  v=(x,y,z,e=Sqrt(x*x+y*y+z*z+m*m))
+~~~
+
+### Vector components in non-cartesian coordinate systems
+There are a couple of member functions to get and set the TVector3
 part of the parameters in
-<BR><B>spherical</B> coordinate systems:
+spherical coordinate systems:
 
-<P><TT>&nbsp; Double_t m, theta, cost, phi, pp, pp2, ppv2, pp2v2;</TT>
-<BR><TT>&nbsp; m = v.Rho();</TT>
-<BR><TT>&nbsp; t = v.Theta();</TT>
-<BR><TT>&nbsp; cost = v.CosTheta();</TT>
-<BR><TT>&nbsp; phi = v.Phi();</TT>
+~~~ {.cpp}
+  Double_t m, theta, cost, phi, pp, pp2, ppv2, pp2v2;
+  m = v.Rho();
+  t = v.Theta();
+  cost = v.CosTheta();
+  phi = v.Phi();
 
-<P><TT>&nbsp; v.SetRho(10.);</TT>
-<BR><TT>&nbsp; v.SetTheta(TMath::Pi()*.3);</TT>
-<BR><TT>&nbsp; v.SetPhi(TMath::Pi());</TT>
+  v.SetRho(10.);
+  v.SetTheta(TMath::Pi()*.3);
+  v.SetPhi(TMath::Pi());
+~~~
 
-<P>or get information about the r-coordinate in <B>cylindrical</B> systems:
+or get information about the r-coordinate in cylindrical systems:
 
-<P><TT>&nbsp; Double_t pp, pp2, ppv2, pp2v2;</TT>
-<BR><TT>&nbsp; pp = v.Perp();&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;// get transvers component</TT>
-<BR><TT>&nbsp; pp2 = v.Perp2();&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;// get transverse component squared</TT>
-<BR><TT>&nbsp; ppv2 = v.Perp(v1);&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; // get
-transvers component with</TT>
-<BR><TT>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;// respect to another vector</TT>
-<BR><TT>&nbsp; pp2v2 = v.Perp(v1);</TT>
+~~~ {.cpp}
+  Double_t pp, pp2, ppv2, pp2v2;
+  pp = v.Perp();         // get transvers component
+  pp2 = v.Perp2();       // get transverse component squared
+  ppv2 = v.Perp(v1);     // get transvers component with
+                         // respect to another vector
+  pp2v2 = v.Perp(v1);
+~~~
 
-<P>for convenience there are two more set functions <TT>SetPtEtaPhiE(pt,eta,phi,e);
-and SetPtEtaPhiM(pt,eta,phi,m);</TT>
-<H3>
-Arithmetic and comparison operators</H3>
-The <TT>TLorentzVecto</TT>r class provides operators to add, subtract or
+for convenience there are two more set functions SetPtEtaPhiE(pt,eta,phi,e);
+and SetPtEtaPhiM(pt,eta,phi,m);
+
+### Arithmetic and comparison operators
+The TLorentzVector class provides operators to add, subtract or
 compare four-vectors:
 
-<P><TT>&nbsp; v3 = -v1;</TT>
-<BR><TT>&nbsp; v1 = v2+v3;</TT>
-<BR><TT>&nbsp; v1+= v3;</TT>
-<BR><TT>&nbsp; v1 = v2 + v3;</TT>
-<BR><TT>&nbsp; v1-= v3;</TT>
+~~~ {.cpp}
+  v3 = -v1;
+  v1 = v2+v3;
+  v1+= v3;
+  v1 = v2 + v3;
+  v1-= v3;
 
-<P><TT>&nbsp; if (v1 == v2) {...}</TT>
-<BR><TT>&nbsp; if(v1 != v3) {...}</TT>
-<H3>
-Magnitude/Invariant mass, beta, gamma, scalar product</H3>
+  if (v1 == v2) {...}
+  if(v1 != v3) {...}
+~~~
+
+### Magnitude/Invariant mass, beta, gamma, scalar product
 The scalar product of two four-vectors is calculated with the (-,-,-,+)
 metric,
-<BR>&nbsp;&nbsp; i.e.&nbsp;&nbsp; <TT><B>s = v1*v2 = </B>t1*t2-x1*x2-y1*y2-z1*z2</TT>
-<BR>The magnitude squared <B><TT>mag2</TT></B> of a four-vector is therfore:
-<BR>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; <TT>mag2<B>
-= v*v = </B>t*t-x*x-y*y-z*z</TT>
-<BR>It <TT>mag2</TT> is negative <TT>mag = -Sqrt(-mag*mag)</TT>. The member
+
+   i.e.   `s = v1*v2 = t1*t2-x1*x2-y1*y2-z1*z2`
+The magnitude squared mag2 of a four-vector is therefore:
+
+~~~ {.cpp}
+          mag2 = v*v = t*t-x*x-y*y-z*z
+~~~
+It mag2 is negative mag = -Sqrt(-mag*mag). The member
 functions are:
 
-<P><TT>&nbsp; Double_t s, s2;</TT>
-<BR><TT>&nbsp; s&nbsp; = v1.Dot(v2);&nbsp;&nbsp;&nbsp;&nbsp; // scalar
-product</TT>
-<BR><TT>&nbsp; s&nbsp; = v1*v2;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;// scalar product</TT>
-<BR><TT>&nbsp; s2 = v.Mag2();&nbsp;&nbsp; or&nbsp;&nbsp;&nbsp; s2 = v.M2();</TT>
-<BR><TT>&nbsp; s&nbsp; = v.Mag();&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-s&nbsp; = v.M();</TT>
+~~~ {.cpp}
+  Double_t s, s2;
+  s  = v1.Dot(v2);     // scalar product
+  s  = v1*v2;          // scalar product
+  s2 = v.Mag2();   or    s2 = v.M2();
+  s  = v.Mag();          s  = v.M();
+~~~
 
-<P>Since in case of momentum and energy the magnitude has the meaning of
-invariant mass <TT>TLorentzVector</TT> provides the more meaningful aliases
-<TT>M2()</TT> and <TT>M()</TT>;
-<P>The member functions <TT>Beta()</TT> and <TT>Gamma()</TT> returns
-<TT>beta</TT> and <tt>gamma = 1/Sqrt(1-beta*beta)</tt>.
-<H3>
-Lorentz boost</H3>
-A boost in a general direction can be parameterized with three parameters
-which can be taken as the components of a three vector <TT><B>b </B>= (bx,by,bz)</TT>.
-With
-<BR><TT><B>&nbsp; x</B> = (x,y,z) and gamma = 1/Sqrt(1-beta*beta)</TT> (beta being the module of vector b),
-an arbitary active Lorentz boost transformation (from the rod frame
+Since in case of momentum and energy the magnitude has the meaning of
+invariant mass TLorentzVector provides the more meaningful aliases
+M2() and M();
+The member functions Beta() and Gamma() returns
+beta and gamma = 1/Sqrt(1-beta*beta).
+### Lorentz boost
+A boost in a general direction can be parameterised with three parameters
+which can be taken as the components of a three vector b = (bx,by,bz).
+With x = (x,y,z) and gamma = 1/Sqrt(1-beta*beta) (beta being the module of vector b),
+an arbitrary active Lorentz boost transformation (from the rod frame
 to the original frame) can be written as:
-<BR>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; <TT><B>x</B>
-= <B>x'</B> + (gamma-1)/(beta*beta) * (<B>b</B>*<B>x'</B>) * <B>b</B> +
-gamma * t' *<B> b</B></TT>
-<BR><B>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </B><TT>t
-= gamma (t'+ <B>b</B>*<B>x'</B>).</TT>
 
-<P>The member function <TT>Boost()</TT> performs a boost transformation
-from the rod frame to the original frame. <TT>BoostVector()</TT> returns
-a <TT>TVector3</TT> of the spatial components divided by the time component:
+~~~ {.cpp}
+          x = x' + (gamma-1)/(beta*beta) * (b*x') * b + gamma * t' * b
+          t = gamma (t'+ b*x').
+~~~
 
-<P><TT>&nbsp; TVector3 b;</TT>
-<BR><TT>&nbsp; v.Boost(bx,by,bz);</TT>
-<BR><TT>&nbsp; v.Boost(b);</TT>
-<BR><TT>&nbsp; b = v.BoostVector();&nbsp;&nbsp; // b=(x/t,y/t,z/t)</TT>
-<H3>
-Rotations</H3>
-There are four sets of functions to rotate the <TT>TVector3</TT> component
-of a <TT>TLorentzVector</TT>:
-<H5>
-rotation around axes</H5>
-<TT>&nbsp; v.RotateX(TMath::Pi()/2.);</TT>
-<BR><TT>&nbsp; v.RotateY(.5);</TT>
-<BR><TT>&nbsp; v.RotateZ(.99);</TT>
-<H5>
-rotation around an arbitary axis</H5>
-<TT>&nbsp; v.Rotate(TMath::Pi()/4., v1); // rotation around v1</TT>
-<H5>
-transformation from rotated frame</H5>
-<TT>&nbsp; v.RotateUz(direction); //&nbsp; direction must be a unit TVector3</TT>
-<H5>
-by TRotation (see TRotation)</H5>
-<TT>&nbsp; TRotation r;</TT>
-<BR><TT>&nbsp; v.Transform(r);&nbsp;&nbsp;&nbsp; or&nbsp;&nbsp;&nbsp;&nbsp;
-v *= r; // Attention v=M*v</TT>
-<H3>
-Misc</H3>
+The member function Boost() performs a boost transformation
+from the rod frame to the original frame. BoostVector() returns
+a TVector3 of the spatial components divided by the time component:
 
-<H5>
-Angle between two vectors</H5>
-<TT>&nbsp; Double_t a = v1.Angle(v2.Vect());&nbsp; // get angle between v1 and
-v2</TT>
-<H5>
-Light-cone components</H5>
-Member functions <TT>Plus()</TT> and <TT>Minus(</TT>) return the positive
-and negative light-cone components:<TT></TT>
+~~~ {.cpp}
+  TVector3 b;
+  v.Boost(bx,by,bz);
+  v.Boost(b);
+  b = v.BoostVector();   // b=(x/t,y/t,z/t)
+~~~
 
-<P><TT>&nbsp; Double_t pcone = v.Plus();</TT>
-<BR><TT>&nbsp; Double_t mcone = v.Minus();</TT>
-<P>CAVEAT: The values returned are T{+,-}Z. It is known that some authors
+### Rotations
+There are four sets of functions to rotate the TVector3 component
+of a TLorentzVector:
+
+#### rotation around axes
+
+~~~ {.cpp}
+  v.RotateX(TMath::Pi()/2.);
+  v.RotateY(.5);
+  v.RotateZ(.99);
+~~~
+
+#### rotation around an arbitrary axis
+  v.Rotate(TMath::Pi()/4., v1); // rotation around v1
+
+#### transformation from rotated frame
+
+~~~ {.cpp}
+  v.RotateUz(direction); //  direction must be a unit TVector3
+~~~
+
+#### by TRotation (see TRotation)
+
+~~~ {.cpp}
+  TRotation r;
+  v.Transform(r);    or     v *= r; // Attention v=M*v
+~~~
+
+### Misc
+
+#### Angle between two vectors
+
+~~~ {.cpp}
+  Double_t a = v1.Angle(v2.Vect());  // get angle between v1 and v2
+~~~
+
+#### Light-cone components
+Member functions Plus() and Minus() return the positive
+and negative light-cone components:
+
+~~~ {.cpp}
+  Double_t pcone = v.Plus();
+  Double_t mcone = v.Minus();
+~~~
+
+CAVEAT: The values returned are T{+,-}Z. It is known that some authors
 find it easier to define these components as (T{+,-}Z)/sqrt(2). Thus
 check what definition is used in the physics you're working in and adapt
 your code accordingly.
-   
-<H5>
-Transformation by TLorentzRotation</H5>
-A general Lorentz transformation see class <TT>TLorentzRotation</TT> can
-be used by the <TT>Transform()</TT> member function, the <TT>*=</TT> or
-<TT>*</TT> operator of the <TT>TLorentzRotation</TT> class:<TT></TT>
 
-<P><TT>&nbsp; TLorentzRotation l;</TT>
-<BR><TT>&nbsp; v.Transform(l);</TT>
-<BR><TT>&nbsp; v = l*v;&nbsp;&nbsp;&nbsp;&nbsp; or&nbsp;&nbsp;&nbsp;&nbsp;
-v *= l;&nbsp; // Attention v = l*v</TT>
+#### Transformation by TLorentzRotation
+A general Lorentz transformation see class TLorentzRotation can
+be used by the Transform() member function, the *= or
+* operator of the TLorentzRotation class:
 
-<P>
-<!--*/
-// -->END_HTML
+~~~ {.cpp}
+  TLorentzRotation l;
+  v.Transform(l);
+  v = l*v;     or     v *= l;  // Attention v = l*v
+~~~
+*/
 
+#include "TLorentzVector.h"
+
+#include "TBuffer.h"
 #include "TClass.h"
 #include "TError.h"
-#include "TLorentzVector.h"
 #include "TLorentzRotation.h"
 
 ClassImp(TLorentzVector)
 
-TLorentzVector::TLorentzVector()
-               : fP(), fE(0.0) {}
-
-TLorentzVector::TLorentzVector(Double_t x, Double_t y, Double_t z, Double_t t)
-               : fP(x,y,z), fE(t) {}
-
-TLorentzVector::TLorentzVector(const Double_t * x0)
-               : fP(x0), fE(x0[3]) {}
-
-TLorentzVector::TLorentzVector(const Float_t * x0)
-               : fP(x0), fE(x0[3]) {}
-
-TLorentzVector::TLorentzVector(const TVector3 & p, Double_t e)
-               : fP(p), fE(e) {}
-
-TLorentzVector::TLorentzVector(const TLorentzVector & p) : TObject(p)
-               , fP(p.Vect()), fE(p.T()) {}
-
-TLorentzVector::~TLorentzVector()  {}
-
-Double_t TLorentzVector::operator () (int i) const
-{
-   //dereferencing operator const
-   switch(i) {
-      case kX:
-      case kY:
-      case kZ:
-         return fP(i);
-      case kT:
-         return fE;
-      default:
-         Error("operator()()", "bad index (%d) returning 0",i);
-   }
-   return 0.;
-}
-
-Double_t & TLorentzVector::operator () (int i)
-{
-   //dereferencing operator
-   switch(i) {
-      case kX:
-      case kY:
-      case kZ:
-         return fP(i);
-      case kT:
-         return fE;
-      default:
-         Error("operator()()", "bad index (%d) returning &fE",i);
-   }
-   return fE;
-}
 
 void TLorentzVector::Boost(Double_t bx, Double_t by, Double_t bz)
 {
@@ -352,10 +305,11 @@ void TLorentzVector::Streamer(TBuffer &R__b)
 }
 
 
-//______________________________________________________________________________
+////////////////////////////////////////////////////////////////////////////////
+/// Print the TLorentz vector components as (x,y,z,t) and (P,eta,phi,E) representations
+
 void TLorentzVector::Print(Option_t *) const
 {
-  // Print the TLorentz vector components as (x,y,z,t) and (P,eta,phi,E) representations
   Printf("(x,y,z,t)=(%f,%f,%f,%f) (P,eta,phi,E)=(%f,%f,%f,%f)",
     fP.x(),fP.y(),fP.z(),fE,
     P(),Eta(),Phi(),fE);

--- a/math/physics/src/TVector3.cxx
+++ b/math/physics/src/TVector3.cxx
@@ -6,232 +6,196 @@
 //    Oct 20 1999: Bug fix: sign in PseudoRapidity
 //                 Warning-> Error in Double_t operator()
 
-//______________________________________________________________________________
-//*-*-*-*-*-*-*-*-*-*-*-*The Physics Vector package *-*-*-*-*-*-*-*-*-*-*-*
-//*-*                    ==========================                       *
-//*-* The Physics Vector package consists of five classes:                *
-//*-*   - TVector2                                                        *
-//*-*   - TVector3                                                        *
-//*-*   - TRotation                                                       *
-//*-*   - TLorentzVector                                                  *
-//*-*   - TLorentzRotation                                                *
-//*-* It is a combination of CLHEPs Vector package written by             *
-//*-* Leif Lonnblad, Andreas Nilsson and Evgueni Tcherniaev               *
-//*-* and a ROOT package written by Pasha Murat.                          *
-//*-* for CLHEP see:  http://wwwinfo.cern.ch/asd/lhc++/clhep/             *
-//*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
-//BEGIN_HTML <!--
-/* -->
-<H2>
-TVector3</H2>
-<TT>TVector3</TT> is a general three vector class, which can be used for
+/** \class TVector3
+    \ingroup Physics
+
+TVector3 is a general three vector class, which can be used for
 the description of different vectors in 3D.
-<H3>
-Declaration / Access to the components</H3>
-<TT>TVector3</TT> has been implemented as a vector of three <TT>Double_t</TT>
+
+### Declaration / Access to the components
+
+TVector3 has been implemented as a vector of three Double_t
 variables, representing the cartesian coordinates. By default all components
 are initialized to zero:
 
-<P><TT>&nbsp; TVector3 v1;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; //
-v1 = (0,0,0)</TT>
-<BR><TT>&nbsp; TVector3 v3(1,2,3); // v3 = (1,2,3)</TT>
-<BR><TT>&nbsp; TVector3 v4(v2);&nbsp;&nbsp;&nbsp; // v4 = v2</TT>
+~~~
+ TVector3 v1;        // v1 = (0,0,0)
+ TVector3 v3(1,2,3); // v3 = (1,2,3)
+ TVector3 v4(v2);    // v4 = v2
+~~~
 
-<P>It is also possible (but not recommended) to initialize a <TT>TVector3</TT>
-with a <TT>Double_t</TT> or <TT>Float_t</TT> C array.
+It is also possible (but not recommended) to initialize a TVector3
+with a Double_t or Float_t C array.
 
-<P>You can get the basic components either by name or by index using <TT>operator()</TT>:
+You can get the basic components either by name or by index using operator():
 
-<P><TT>&nbsp; xx = v1.X();&nbsp;&nbsp;&nbsp; or&nbsp;&nbsp;&nbsp; xx =
-v1(0);</TT>
-<BR><TT>&nbsp; yy = v1.Y();&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-yy = v1(1);</TT>
-<BR><TT>&nbsp; zz = v1.Z();&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-zz = v1(2);</TT>
+~~~
+ xx = v1.X(); or xx = v1(0);
+ yy = v1.Y();    yy = v1(1);
+ zz = v1.Z();    zz = v1(2);
+~~~
 
-<P>The memberfunctions <TT>SetX()</TT>, <TT>SetY()</TT>, <TT>SetZ()</TT>
-and<TT> SetXYZ()</TT> allow to set the components:
+The member functions SetX(), SetY(), SetZ() and SetXYZ() allow to set the components:
 
-<P><TT>&nbsp; v1.SetX(1.); v1.SetY(2.); v1.SetZ(3.);</TT>
-<BR><TT>&nbsp; v1.SetXYZ(1.,2.,3.);</TT>
-<BR>&nbsp;
-<H3>
-Noncartesian coordinates</H3>
-To get information on the <TT>TVector3</TT> in spherical (rho,phi,theta)
+~~~
+ v1.SetX(1.); v1.SetY(2.); v1.SetZ(3.);
+ v1.SetXYZ(1.,2.,3.);
+~~~
+
+### Non-cartesian coordinates
+
+To get information on the TVector3 in spherical (rho,phi,theta)
 or cylindrical (z,r,theta) coordinates, the
-<BR>the member functions <TT>Mag()</TT> (=magnitude=rho in spherical coordinates),
-<TT>Mag2()</TT>, <TT>Theta()</TT>, <TT>CosTheta()</TT>, <TT>Phi()</TT>,
-<TT>Perp()</TT> (the transverse component=r in cylindrical coordinates),
-<TT>Perp2()</TT> can be used:
 
-<P><TT>&nbsp; Double_t m&nbsp; = v.Mag();&nbsp;&nbsp;&nbsp; // get magnitude
-(=rho=Sqrt(x*x+y*y+z*z)))</TT>
-<BR><TT>&nbsp; Double_t m2 = v.Mag2();&nbsp;&nbsp; // get magnitude squared</TT>
-<BR><TT>&nbsp; Double_t t&nbsp; = v.Theta();&nbsp; // get polar angle</TT>
-<BR><TT>&nbsp; Double_t ct = v.CosTheta();// get cos of theta</TT>
-<BR><TT>&nbsp; Double_t p&nbsp; = v.Phi();&nbsp;&nbsp;&nbsp; // get azimuth
-angle</TT>
-<BR><TT>&nbsp; Double_t pp = v.Perp();&nbsp;&nbsp; // get transverse component</TT>
-<BR><TT>&nbsp; Double_t pp2= v.Perp2();&nbsp; // get transvers component
-squared</TT>
+the member functions Mag() (=magnitude=rho in spherical coordinates),
+Mag2(), Theta(), CosTheta(), Phi(), Perp() (the transverse component=r in
+cylindrical coordinates), Perp2() can be used:
 
-<P>It is also possible to get the transverse component with respect to
+
+~~~
+ Double_t m = v.Mag();       // get magnitude (=rho=Sqrt(x*x+y*y+z*z)))
+ Double_t m2 = v.Mag2();     // get magnitude squared
+ Double_t t = v.Theta();     // get polar angle
+ Double_t ct = v.CosTheta(); // get cos of theta
+ Double_t p = v.Phi();       // get azimuth angle
+ Double_t pp = v.Perp();     // get transverse component
+ Double_t pp2= v.Perp2();    // get transvers component squared
+~~~
+
+It is also possible to get the transverse component with respect to
 another vector:
 
-<P><TT>&nbsp; Double_t ppv1 = v.Perp(v1);</TT>
-<BR><TT>&nbsp; Double_t pp2v1 = v.Perp2(v1);</TT>
+~~~
+ Double_t ppv1 = v.Perp(v1);
+ Double_t pp2v1 = v.Perp2(v1);
+~~~
 
-<P>The pseudo-rapidity ( eta=-ln (tan (theta/2)) ) can be obtained by <TT>Eta()</TT>
-or <TT>PseudoRapidity()</TT>:
-<BR>&nbsp;
-<BR><TT>&nbsp; Double_t eta = v.PseudoRapidity();</TT>
+The pseudo-rapidity ( eta=-ln (tan (theta/2)) ) can be obtained by Eta()
+or PseudoRapidity():
 
-<P>There are set functions to change one of the noncartesian coordinates:
+~~~
+ Double_t eta = v.PseudoRapidity();
+~~~
 
-<P><TT>&nbsp; v.SetTheta(.5); // keeping rho and phi</TT>
-<BR><TT>&nbsp; v.SetPhi(.8);&nbsp;&nbsp; // keeping rho and theta</TT>
-<BR><TT>&nbsp; v.SetMag(10.);&nbsp; // keeping theta and phi</TT>
-<BR><TT>&nbsp; v.SetPerp(3.);&nbsp; // keeping z and phi</TT>
-<BR>&nbsp;
-<H3>
-Arithmetic / Comparison</H3>
-The <TT>TVector3</TT> class provides the operators to add, subtract, scale and compare
+There are set functions to change one of the non-cartesian coordinates:
+
+~~~
+ v.SetTheta(.5); // keeping rho and phi
+ v.SetPhi(.8);   // keeping rho and theta
+ v.SetMag(10.);  // keeping theta and phi
+ v.SetPerp(3.);  // keeping z and phi
+~~~
+
+### Arithmetic / Comparison
+
+The TVector3 class provides the operators to add, subtract, scale and compare
 vectors:
 
-<P><TT>&nbsp; v3&nbsp; = -v1;</TT>
-<BR><TT>&nbsp; v1&nbsp; = v2+v3;</TT>
-<BR><TT>&nbsp; v1 += v3;</TT>
-<BR><TT>&nbsp; v1&nbsp; = v1 - v3</TT>
-<BR><TT>&nbsp; v1 -= v3;</TT>
-<BR><TT>&nbsp; v1 *= 10;</TT>
-<BR><TT>&nbsp; v1&nbsp; = 5*v2;</TT>
+~~~
+ v3  = -v1;
+ v1  = v2+v3;
+ v1 += v3;
+ v1  = v1 - v3
+ v1 -= v3;
+ v1 *= 10;
+ v1  = 5*v2;
+ if (v1==v2) {...}
+ if (v1!=v2) {...}
+~~~
 
-<P><TT>&nbsp; if(v1==v2) {...}</TT>
-<BR><TT>&nbsp; if(v1!=v2) {...}</TT>
-<BR>&nbsp;
-<H3>
-Related Vectors</H3>
-<TT>&nbsp; v2 = v1.Unit();&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; // get unit
-vector parallel to v1</TT>
-<BR><TT>&nbsp; v2 = v1.Orthogonal(); // get vector orthogonal to v1</TT>
-<H3>
-Scalar and vector products</H3>
-<TT>&nbsp; s = v1.Dot(v2);&nbsp;&nbsp; // scalar product</TT>
-<BR><TT>&nbsp; s = v1 * v2;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; // scalar product</TT>
-<BR><TT>&nbsp; v = v1.Cross(v2); // vector product</TT>
-<H3>
-&nbsp;Angle between two vectors</H3>
-<TT>&nbsp; Double_t a = v1.Angle(v2);</TT>
-<H3>
-Rotations</H3>
+### Related Vectors
 
-<H5>
-Rotation around axes</H5>
-<TT>&nbsp; v.RotateX(.5);</TT>
-<BR><TT>&nbsp; v.RotateY(TMath::Pi());</TT>
-<BR><TT>&nbsp; v.RotateZ(angle);</TT>
-<H5>
-Rotation around a vector</H5>
-<TT>&nbsp; v1.Rotate(TMath::Pi()/4, v2); // rotation around v2</TT>
-<H5>
-Rotation by TRotation</H5>
-<TT>TVector3</TT> objects can be rotated by objects of the <TT>TRotation</TT>
-class using the <TT>Transform()</TT> member functions,
-<BR>the <TT>operator *=</TT> or the <TT>operator *</TT> of the TRotation
-class:
+~~~
+ v2 = v1.Unit(); // get unit vector parallel to v1
+ v2 = v1.Orthogonal(); // get vector orthogonal to v1
+~~~
 
-<P><TT>&nbsp; TRotation m;</TT>
-<BR><TT>&nbsp; ...</TT>
-<BR><TT>&nbsp; v1.transform(m);</TT>
-<BR><TT>&nbsp; v1 = m*v1;</TT>
-<BR><TT>&nbsp; v1 *= m; // Attention v1 = m*v1</TT>
-<H5>
-Transformation from rotated frame</H5>
-<TT>&nbsp; TVector3 direction = v.Unit()</TT>
-<BR><TT>&nbsp; v1.RotateUz(direction); // direction must be TVector3 of
-unit length</TT>
+### Scalar and vector products
 
-<P>transforms v1 from the rotated frame (z' parallel to direction, x' in
+~~~
+ s = v1.Dot(v2);   // scalar product
+ s = v1 * v2;      // scalar product
+ v = v1.Cross(v2); // vector product
+~~~
+
+### Angle between two vectors
+
+~~~
+ Double_t a = v1.Angle(v2);
+~~~
+
+### Rotations
+
+#### Rotation around axes
+
+~~~
+ v.RotateX(.5);
+ v.RotateY(TMath::Pi());
+ v.RotateZ(angle);
+~~~
+
+#### Rotation around a vector
+
+~~~
+ v1.Rotate(TMath::Pi()/4, v2); // rotation around v2
+~~~
+
+#### Rotation by TRotation
+TVector3 objects can be rotated by objects of the TRotation
+class using the Transform() member functions,
+
+the operator *= or the operator * of the TRotation class:
+
+~~~
+ TRotation m;
+ ...
+ v1.transform(m);
+ v1  = m*v1;
+ v1 *= m; // Attention v1 = m*v1
+~~~
+
+#### Transformation from rotated frame
+
+~~~
+ TVector3 direction = v.Unit()
+ v1.RotateUz(direction); // direction must be TVector3 of unit length
+~~~
+
+transforms v1 from the rotated frame (z' parallel to direction, x' in
 the theta plane and y' in the xy plane as well as perpendicular to the
 theta plane) to the (x,y,z) frame.
+*/
 
-<!--*/
-// -->END_HTML
-//
 
 #include "TVector3.h"
+
+#include "TBuffer.h"
 #include "TRotation.h"
 #include "TMath.h"
 #include "TClass.h"
 
 ClassImp(TVector3)
 
-//______________________________________________________________________________
-TVector3::TVector3()
-: fX(0.0), fY(0.0), fZ(0.0) {}
 
-TVector3::TVector3(const TVector3 & p) : TObject(p),
-  fX(p.fX), fY(p.fY), fZ(p.fZ) {}
+////////////////////////////////////////////////////////////////////////////////
+/// Multiplication operator
 
-TVector3::TVector3(Double_t xx, Double_t yy, Double_t zz)
-: fX(xx), fY(yy), fZ(zz) {}
-
-TVector3::TVector3(const Double_t * x0)
-: fX(x0[0]), fY(x0[1]), fZ(x0[2]) {}
-
-TVector3::TVector3(const Float_t * x0)
-: fX(x0[0]), fY(x0[1]), fZ(x0[2]) {}
-
-TVector3::~TVector3() {}
-
-//______________________________________________________________________________
-Double_t TVector3::operator () (int i) const {
-   //dereferencing operator const
-   switch(i) {
-      case 0:
-         return fX;
-      case 1:
-         return fY;
-      case 2:
-         return fZ;
-      default:
-         Error("operator()(i)", "bad index (%d) returning 0",i);
-   }
-   return 0.;
-}
-
-//______________________________________________________________________________
-Double_t & TVector3::operator () (int i) {
-   //dereferencing operator
-   switch(i) {
-      case 0:
-         return fX;
-      case 1:
-         return fY;
-      case 2:
-         return fZ;
-      default:
-         Error("operator()(i)", "bad index (%d) returning &fX",i);
-   }
-   return fX;
-}
-
-//______________________________________________________________________________
 TVector3 & TVector3::operator *= (const TRotation & m){
-   //multiplication operator
    return *this = m * (*this);
 }
 
-//______________________________________________________________________________
+////////////////////////////////////////////////////////////////////////////////
+/// Transform this vector with a TRotation
+
 TVector3 & TVector3::Transform(const TRotation & m) {
-   //transform this vector with a TRotation
    return *this = m * (*this);
 }
 
-//______________________________________________________________________________
-Double_t TVector3::Angle(const TVector3 & q) const 
+////////////////////////////////////////////////////////////////////////////////
+/// Return the angle w.r.t. another 3-vector.
+
+Double_t TVector3::Angle(const TVector3 & q) const
 {
-   // return the angle w.r.t. another 3-vector
    Double_t ptot2 = Mag2()*q.Mag2();
    if(ptot2 <= 0) {
       return 0.0;
@@ -243,58 +207,54 @@ Double_t TVector3::Angle(const TVector3 & q) const
    }
 }
 
-//______________________________________________________________________________
-Double_t TVector3::Mag() const 
-{ 
-   // return the magnitude (rho in spherical coordinate system)
-   
-   return TMath::Sqrt(Mag2()); 
-}
+////////////////////////////////////////////////////////////////////////////////
+/// Return the transverse component  (R in cylindrical coordinate system)
 
-//______________________________________________________________________________
-Double_t TVector3::Perp() const 
-{ 
-   //return the transverse component  (R in cylindrical coordinate system)
-
-   return TMath::Sqrt(Perp2()); 
-}
-
-
-//______________________________________________________________________________
-Double_t TVector3::Perp(const TVector3 & p) const
-{ 
-   //return the transverse component (R in cylindrical coordinate system)
-
-   return TMath::Sqrt(Perp2(p)); 
-}
-
-//______________________________________________________________________________
-Double_t TVector3::Phi() const 
+Double_t TVector3::Perp() const
 {
-   //return the  azimuth angle. returns phi from -pi to pi
+   return TMath::Sqrt(Perp2());
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+/// Return the transverse component (R in cylindrical coordinate system)
+
+Double_t TVector3::Perp(const TVector3 & p) const
+{
+   return TMath::Sqrt(Perp2(p));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Return the azimuth angle. Returns phi from -pi to pi.
+
+Double_t TVector3::Phi() const
+{
    return fX == 0.0 && fY == 0.0 ? 0.0 : TMath::ATan2(fY,fX);
 }
 
-//______________________________________________________________________________
-Double_t TVector3::Theta() const 
+////////////////////////////////////////////////////////////////////////////////
+/// Return the polar angle
+
+Double_t TVector3::Theta() const
 {
-   //return the polar angle
    return fX == 0.0 && fY == 0.0 && fZ == 0.0 ? 0.0 : TMath::ATan2(Perp(),fZ);
 }
 
-//______________________________________________________________________________
-TVector3 TVector3::Unit() const 
+////////////////////////////////////////////////////////////////////////////////
+/// Return unit vector parallel to this.
+
+TVector3 TVector3::Unit() const
 {
-   // return unit vector parallel to this.
    Double_t  tot2 = Mag2();
    Double_t tot = (tot2 > 0) ?  1.0/TMath::Sqrt(tot2) : 1.0;
    TVector3 p(fX*tot,fY*tot,fZ*tot);
    return p;
 }
 
-//______________________________________________________________________________
+////////////////////////////////////////////////////////////////////////////////
+/// Rotate vector around X.
+
 void TVector3::RotateX(Double_t angle) {
-   //rotate vector around X
    Double_t s = TMath::Sin(angle);
    Double_t c = TMath::Cos(angle);
    Double_t yy = fY;
@@ -302,9 +262,10 @@ void TVector3::RotateX(Double_t angle) {
    fZ = s*yy + c*fZ;
 }
 
-//______________________________________________________________________________
+////////////////////////////////////////////////////////////////////////////////
+/// Rotate vector around Y.
+
 void TVector3::RotateY(Double_t angle) {
-   //rotate vector around Y
    Double_t s = TMath::Sin(angle);
    Double_t c = TMath::Cos(angle);
    Double_t zz = fZ;
@@ -312,9 +273,10 @@ void TVector3::RotateY(Double_t angle) {
    fX = s*zz + c*fX;
 }
 
-//______________________________________________________________________________
+////////////////////////////////////////////////////////////////////////////////
+/// Rotate vector around Z.
+
 void TVector3::RotateZ(Double_t angle) {
-   //rotate vector around Z
    Double_t s = TMath::Sin(angle);
    Double_t c = TMath::Cos(angle);
    Double_t xx = fX;
@@ -322,18 +284,19 @@ void TVector3::RotateZ(Double_t angle) {
    fY = s*xx + c*fY;
 }
 
-//______________________________________________________________________________
+////////////////////////////////////////////////////////////////////////////////
+/// Rotate vector.
+
 void TVector3::Rotate(Double_t angle, const TVector3 & axis){
-   //rotate vector
    TRotation trans;
    trans.Rotate(angle, axis);
    operator*=(trans);
 }
 
-//______________________________________________________________________________
-void TVector3::RotateUz(const TVector3& NewUzVector) {
-   // NewUzVector must be normalized !
+////////////////////////////////////////////////////////////////////////////////
+/// NewUzVector must be normalized !
 
+void TVector3::RotateUz(const TVector3& NewUzVector) {
    Double_t u1 = NewUzVector.fX;
    Double_t u2 = NewUzVector.fY;
    Double_t u3 = NewUzVector.fZ;
@@ -349,39 +312,43 @@ void TVector3::RotateUz(const TVector3& NewUzVector) {
    else {};
 }
 
-//______________________________________________________________________________
+////////////////////////////////////////////////////////////////////////////////
+/// Double_t m = Mag();
+/// return 0.5*log( (m+fZ)/(m-fZ) );
+/// guard against Pt=0
+
 Double_t TVector3::PseudoRapidity() const {
-   //Double_t m = Mag();
-   //return 0.5*log( (m+fZ)/(m-fZ) );
-   // guard against Pt=0
    double cosTheta = CosTheta();
    if (cosTheta*cosTheta < 1) return -0.5* TMath::Log( (1.0-cosTheta)/(1.0+cosTheta) );
    if (fZ == 0) return 0;
-   Warning("PseudoRapidity","transvers momentum = 0! return +/- 10e10");
+   //Warning("PseudoRapidity","transvers momentum = 0! return +/- 10e10");
    if (fZ > 0) return 10e10;
    else        return -10e10;
 }
 
-//______________________________________________________________________________
+////////////////////////////////////////////////////////////////////////////////
+/// Set Pt, Eta and Phi
+
 void TVector3::SetPtEtaPhi(Double_t pt, Double_t eta, Double_t phi) {
-   //set Pt, Eta and Phi
    Double_t apt = TMath::Abs(pt);
    SetXYZ(apt*TMath::Cos(phi), apt*TMath::Sin(phi), apt/TMath::Tan(2.0*TMath::ATan(TMath::Exp(-eta))) );
 }
 
-//______________________________________________________________________________
+////////////////////////////////////////////////////////////////////////////////
+/// Set Pt, Theta and Phi
+
 void TVector3::SetPtThetaPhi(Double_t pt, Double_t theta, Double_t phi) {
-   //set Pt, Theta and Phi
    fX = pt * TMath::Cos(phi);
-   fY = pt * TMath::Sin(phi); 
+   fY = pt * TMath::Sin(phi);
    Double_t tanTheta = TMath::Tan(theta);
    fZ = tanTheta ? pt / tanTheta : 0;
 }
 
-//______________________________________________________________________________
-void TVector3::SetTheta(Double_t th) 
+////////////////////////////////////////////////////////////////////////////////
+/// Set theta keeping mag and phi constant (BaBar).
+
+void TVector3::SetTheta(Double_t th)
 {
-   // Set theta keeping mag and phi constant (BaBar).
    Double_t ma   = Mag();
    Double_t ph   = Phi();
    SetX(ma*TMath::Sin(th)*TMath::Cos(ph));
@@ -389,39 +356,42 @@ void TVector3::SetTheta(Double_t th)
    SetZ(ma*TMath::Cos(th));
 }
 
-//______________________________________________________________________________
-void TVector3::SetPhi(Double_t ph) 
+////////////////////////////////////////////////////////////////////////////////
+/// Set phi keeping mag and theta constant (BaBar).
+
+void TVector3::SetPhi(Double_t ph)
 {
-   // Set phi keeping mag and theta constant (BaBar).
    Double_t xy   = Perp();
    SetX(xy*TMath::Cos(ph));
    SetY(xy*TMath::Sin(ph));
 }
 
-//______________________________________________________________________________
-Double_t TVector3::DeltaR(const TVector3 & v) const 
+////////////////////////////////////////////////////////////////////////////////
+/// Return deltaR with respect to v.
+
+Double_t TVector3::DeltaR(const TVector3 & v) const
 {
-   //return deltaR with respect to v
    Double_t deta = Eta()-v.Eta();
    Double_t dphi = TVector2::Phi_mpi_pi(Phi()-v.Phi());
    return TMath::Sqrt( deta*deta+dphi*dphi );
 }
 
-//______________________________________________________________________________
-void TVector3::SetMagThetaPhi(Double_t mag, Double_t theta, Double_t phi) 
+////////////////////////////////////////////////////////////////////////////////
+/// Setter with mag, theta, phi.
+
+void TVector3::SetMagThetaPhi(Double_t mag, Double_t theta, Double_t phi)
 {
-   //setter with mag, theta, phi
    Double_t amag = TMath::Abs(mag);
    fX = amag * TMath::Sin(theta) * TMath::Cos(phi);
    fY = amag * TMath::Sin(theta) * TMath::Sin(phi);
    fZ = amag * TMath::Cos(theta);
 }
 
-//______________________________________________________________________________
+////////////////////////////////////////////////////////////////////////////////
+/// Stream an object of class TVector3.
+
 void TVector3::Streamer(TBuffer &R__b)
 {
-   // Stream an object of class TVector3.
-
    if (R__b.IsReading()) {
       UInt_t R__s, R__c;
       Version_t R__v = R__b.ReadVersion(&R__s, &R__c);
@@ -436,31 +406,47 @@ void TVector3::Streamer(TBuffer &R__b)
       R__b >> fZ;
       R__b.CheckByteCount(R__s, R__c, TVector3::IsA());
       //====end of old versions
-      
+
    } else {
       R__b.WriteClassBuffer(TVector3::Class(),this);
    }
 }
 
+////////////////////////////////////////////////////////////////////////////////
+/// Operator +
+
 TVector3 operator + (const TVector3 & a, const TVector3 & b) {
    return TVector3(a.X() + b.X(), a.Y() + b.Y(), a.Z() + b.Z());
 }
+
+////////////////////////////////////////////////////////////////////////////////
+/// Operator -
 
 TVector3 operator - (const TVector3 & a, const TVector3 & b) {
    return TVector3(a.X() - b.X(), a.Y() - b.Y(), a.Z() - b.Z());
 }
 
+////////////////////////////////////////////////////////////////////////////////
+/// Operator *
+
 TVector3 operator * (const TVector3 & p, Double_t a) {
    return TVector3(a*p.X(), a*p.Y(), a*p.Z());
 }
+
+////////////////////////////////////////////////////////////////////////////////
+/// Operator *
 
 TVector3 operator * (Double_t a, const TVector3 & p) {
    return TVector3(a*p.X(), a*p.Y(), a*p.Z());
 }
 
+////////////////////////////////////////////////////////////////////////////////
 Double_t operator * (const TVector3 & a, const TVector3 & b) {
    return a.Dot(b);
 }
+
+////////////////////////////////////////////////////////////////////////////////
+/// Operator *
 
 TVector3 operator * (const TMatrix & m, const TVector3 & v ) {
    return TVector3( m(0,0)*v.X()+m(0,1)*v.Y()+m(0,2)*v.Z(),
@@ -468,14 +454,11 @@ TVector3 operator * (const TMatrix & m, const TVector3 & v ) {
                     m(2,0)*v.X()+m(2,1)*v.Y()+m(2,2)*v.Z());
 }
 
-
-//const TVector3 kXHat(1.0, 0.0, 0.0);
-//const TVector3 kYHat(0.0, 1.0, 0.0);
-//const TVector3 kZHat(0.0, 0.0, 1.0);
+////////////////////////////////////////////////////////////////////////////////
+/// Print vector parameters.
 
 void TVector3::Print(Option_t*)const
 {
-   //print vector parameters
    Printf("%s %s (x,y,z)=(%f,%f,%f) (rho,theta,phi)=(%f,%f,%f)",GetName(),GetTitle(),X(),Y(),Z(),
                                           Mag(),Theta()*TMath::RadToDeg(),Phi()*TMath::RadToDeg());
 }


### PR DESCRIPTION
 * move important functions (constructors,destructors,accessors) to header
   to avoid overhead in creating and accessing these small objects

 * optimize access to TLorentzVector by avoiding a double switch statement
   (switch on direction in TLorentzVector followed by same switch in TVector3)

 * TLorentzVector made friend of TVector3

This commit is a performance patch for ALICE's ROOT production version;
It is "cherry-picked" from the ROOT master branch