### PR TITLE
Update TNetXNGFile to enable local redirect functionality

### DIFF
--- a/net/netxng/inc/TNetXNGFile.h
+++ b/net/netxng/inc/TNetXNGFile.h
@@ -1,4 +1,4 @@
-// @(#)root/netxng:$Id$
+
 /*************************************************************************
  * Copyright (C) 1995-2013, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
@@ -50,14 +50,13 @@ private:
 
 public:
    TNetXNGFile() : TFile(),
-         fFile(0), fUrl(0), fMode(XrdCl::OpenFlags::None), fInitCondVar(0),
-         fReadvIorMax(0), fReadvIovMax(0){}
+      fFile(0), fUrl(0), fMode(XrdCl::OpenFlags::None), fInitCondVar(0),
+      fReadvIorMax(0), fReadvIovMax(0) {}
+   TNetXNGFile(const char *url, const char *lurl, Option_t *mode = "", const char *title = "",
+               Int_t compress = 1, Int_t netopt = 0, Bool_t parallelopen = kFALSE);
    TNetXNGFile(const char *url, Option_t *mode = "", const char *title = "",
-               Int_t compress = 1, Int_t netopt = 0, Bool_t parallelopen = kFALSE,
-	       const char *lurl = 0);
-   TNetXNGFile(const char *url, Option_t *mode = "", const char *title = "",
-               Int_t compress = 1, Int_t netopt = 0, Bool_t parallelopen = kFALSE
-	       );
+               Int_t compress = 1, Int_t netopt = 0, Bool_t parallelopen = kFALSE);
+
    virtual ~TNetXNGFile();
 
    virtual void     Init(Bool_t create);

--- a/net/netxng/inc/TNetXNGFile.h
+++ b/net/netxng/inc/TNetXNGFile.h
@@ -55,6 +55,9 @@ public:
    TNetXNGFile(const char *url, Option_t *mode = "", const char *title = "",
                Int_t compress = 1, Int_t netopt = 0, Bool_t parallelopen = kFALSE,
 	       const char *lurl = 0);
+   TNetXNGFile(const char *url, Option_t *mode = "", const char *title = "",
+               Int_t compress = 1, Int_t netopt = 0, Bool_t parallelopen = kFALSE
+	       );
    virtual ~TNetXNGFile();
 
    virtual void     Init(Bool_t create);

--- a/net/netxng/inc/TNetXNGFile.h
+++ b/net/netxng/inc/TNetXNGFile.h
@@ -52,8 +52,8 @@ public:
    TNetXNGFile() : TFile(),
       fFile(0), fUrl(0), fMode(XrdCl::OpenFlags::None), fInitCondVar(0),
       fReadvIorMax(0), fReadvIovMax(0) {}
-   TNetXNGFile(const char *url, const char *lurl, Option_t *mode = "", const char *title = "",
-               Int_t compress = 1, Int_t netopt = 0, Bool_t parallelopen = kFALSE);
+   TNetXNGFile(const char *url, const char *lurl, Option_t *mode , const char *title ,
+               Int_t compress , Int_t netopt , Bool_t parallelopen );
    TNetXNGFile(const char *url, Option_t *mode = "", const char *title = "",
                Int_t compress = 1, Int_t netopt = 0, Bool_t parallelopen = kFALSE);
 

--- a/net/netxng/inc/TNetXNGFile.h
+++ b/net/netxng/inc/TNetXNGFile.h
@@ -53,7 +53,8 @@ public:
          fFile(0), fUrl(0), fMode(XrdCl::OpenFlags::None), fInitCondVar(0),
          fReadvIorMax(0), fReadvIovMax(0){}
    TNetXNGFile(const char *url, Option_t *mode = "", const char *title = "",
-         Int_t compress = 1, Int_t netopt = 0, Bool_t parallelopen = kFALSE);
+               Int_t compress = 1, Int_t netopt = 0, Bool_t parallelopen = kFALSE,
+	       const char *lurl = 0);
    virtual ~TNetXNGFile();
 
    virtual void     Init(Bool_t create);

--- a/net/netxng/src/TNetXNGFile.cxx
+++ b/net/netxng/src/TNetXNGFile.cxx
@@ -112,8 +112,9 @@ TNetXNGFile::TNetXNGFile(const char *url,
                          const char *title,
                          Int_t       compress,
                          Int_t       /*netopt*/,
-                         Bool_t      parallelopen) :
-   TFile(url, "NET", title, compress)
+                         Bool_t      parallelopen,
+			 const char *lurl) :
+   TFile((lurl ? lurl : url), "NET", title, compress)
 {
    // Constructor
    //
@@ -697,6 +698,18 @@ Bool_t TNetXNGFile::GetVectorReadLimits()
 
    if (!fQueryReadVParams)
       return kTRUE;
+
+   std::string lasturl;
+   fFile->GetProperty("LastURL",lasturl);
+   URL lrl(lasturl);
+   //local redirect will split vector reads into multiple local reads anyway,
+   // so we are fine with the default values
+   if(0==lrl.GetProtocol().compare("file") &&
+      0==lrl.GetHostId().compare("localhost")){
+       if (gDebug>=1) 
+          Info("GetVectorReadLimits","Local redirect, using default values");
+       return kTRUE;
+   }
 
 #if XrdVNUMBER >= 40000
    std::string dataServerStr;

--- a/net/netxng/src/TNetXNGFile.cxx
+++ b/net/netxng/src/TNetXNGFile.cxx
@@ -18,6 +18,7 @@
 //                                                                            //
 ////////////////////////////////////////////////////////////////////////////////
 
+#include "TArchiveFile.h"
 #include "TNetXNGFile.h"
 #include "TEnv.h"
 #include "TSystem.h"
@@ -263,6 +264,9 @@ Long64_t TNetXNGFile::GetSize() const
 {
    // Get the file size. Returns -1 in the case that the file could not be
    // stat'ed.
+   if (fArchive && fArchive->GetMember()) {
+     return fArchive->GetMember()->GetDecompressedSize();
+   }
 
    using namespace XrdCl;
 

--- a/net/netxng/src/TNetXNGFile.cxx
+++ b/net/netxng/src/TNetXNGFile.cxx
@@ -113,15 +113,15 @@ TNetXNGFile::TNetXNGFile(const char *url,
                          Int_t       compress,
                          Int_t       netopt,
                          Bool_t      parallelopen) :
-	TNetXNGFile(url,mode,title,compress,netopt,parallelopen,0){}
+	TNetXNGFile(url,0,mode,title,compress,netopt,parallelopen){}
 
 TNetXNGFile::TNetXNGFile(const char *url,
+		         const char *lurl,
                          Option_t   *mode,
                          const char *title,
                          Int_t       compress,
                          Int_t       /*netopt*/,
-                         Bool_t      parallelopen,
-			 const char *lurl) :
+                         Bool_t      parallelopen) :
    TFile((lurl ? lurl : url), "NET", title, compress)
 {
    // Constructor

--- a/net/netxng/src/TNetXNGFile.cxx
+++ b/net/netxng/src/TNetXNGFile.cxx
@@ -111,6 +111,14 @@ TNetXNGFile::TNetXNGFile(const char *url,
                          Option_t   *mode,
                          const char *title,
                          Int_t       compress,
+                         Int_t       netopt,
+                         Bool_t      parallelopen) :
+	TNetXNGFile(url,mode,title,compress,netopt,parallelopen,0){}
+
+TNetXNGFile::TNetXNGFile(const char *url,
+                         Option_t   *mode,
+                         const char *title,
+                         Int_t       compress,
                          Int_t       /*netopt*/,
                          Bool_t      parallelopen,
 			 const char *lurl) :

--- a/net/netxng/src/TNetXNGFile.cxx
+++ b/net/netxng/src/TNetXNGFile.cxx
@@ -704,9 +704,9 @@ Bool_t TNetXNGFile::GetVectorReadLimits()
    URL lrl(lasturl);
    //local redirect will split vector reads into multiple local reads anyway,
    // so we are fine with the default values
-   if(0==lrl.GetProtocol().compare("file") &&
-      0==lrl.GetHostId().compare("localhost")){
-       if (gDebug>=1) 
+   if(lrl.GetProtocol().compare("file") == 0 &&
+      lrl.GetHostId().compare("localhost") == 0){
+       if (gDebug >= 1)
           Info("GetVectorReadLimits","Local redirect, using default values");
        return kTRUE;
    }
@@ -915,4 +915,3 @@ void TNetXNGFile::SetEnv()
                             || strlen(cenv) <= 0))
       gSystem->Setenv("XrdSecPWDVERIFYSRV",    val.Data());
 }
-

--- a/net/netxng/src/TNetXNGFile.cxx
+++ b/net/netxng/src/TNetXNGFile.cxx
@@ -708,8 +708,7 @@ Bool_t TNetXNGFile::GetVectorReadLimits()
       return kTRUE;
 
    std::string lasturl;
-   fFile->GetProperty("LastURL",lasturl);
-   URL lrl(lasturl);
+   URL lrl(fFile->GetLastURL());
    //local redirect will split vector reads into multiple local reads anyway,
    // so we are fine with the default values
    if(lrl.GetProtocol().compare("file") == 0 &&


### PR DESCRIPTION
ROOT 6 already has most of this code merged in upstream v6-18-04 branch. We have added some patches to make it compatible with XRootD 3.3.6 and to fix reading files from archives.

Key modifications:

- Added new constructor to TNetXNGFile to pass LFN to TFile
- Added local redirect compatibility
- Fixed reading archive member size instead of the whole archive