### PR TITLE
Move std namespace declaration after all includes

### DIFF
--- a/core/dictgen/src/rootcling_impl.cxx
+++ b/core/dictgen/src/rootcling_impl.cxx
@@ -2988,6 +2988,12 @@ void CreateDictHeader(std::ostream &dictStream, const std::string &main_dictname
                << "#include \"TCollectionProxyInfo.h\"\n"
                << "/*******************************************************************/\n\n"
                << "#include \"TDataMember.h\"\n\n"; // To set their transiency
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void AddNamespaceSTDdeclaration(std::ostream &dictStream)
+{
 #ifndef R__SOLARIS
    dictStream  << "// The generated code does not explicitly qualifies STL entities\n"
                << "namespace std {} using namespace std;\n\n";
@@ -4829,6 +4835,10 @@ int RootClingMain(int argc,
       }
    }
 
+   AddNamespaceSTDdeclaration(dictStream);
+   if (doSplit)
+     AddNamespaceSTDdeclaration(splitDictStream);
+   
    if (onepcm) {
       AnnotateAllDeclsForPCH(interp, scan);
    } else if (interpreteronly) {


### PR DESCRIPTION
In order to avoide namespace std interfering with following include files, when generating a dictionary
declare the namespace std only after GenerateNecessaryIncludes method is called

@ktf @chiarazampolli for me this PR fixes the problem of exposing boost headers to rootcling, both in compiled code and in macros. 
The same lines will require a separate [patch](https://github.com/alisw/root/pull/12) for the master 