### PR TITLE
Avoid {using namespace std} in global scope of dictionary [ROOT-10661]

### DIFF
--- a/config/rootrc.in
+++ b/config/rootrc.in
@@ -392,6 +392,8 @@ ACLiC.Linkdef:          _linkdef
 #      needed libraries.
 # On Windows, the default is 3
 #ACLiC.LinkLibs:      1
+# Add extra options to rootcling invocation by ACLiC
+#ACLiC.ExtraRootclingFlags:      [-optA ... -optZ]
 
 # PROOF related variables
 #

--- a/core/base/src/TSystem.cxx
+++ b/core/base/src/TSystem.cxx
@@ -3567,6 +3567,12 @@ int TSystem::CompileMacro(const char *filename, Option_t *opt,
    if (gEnv) {
       TString fromConfig = gEnv->GetValue("ACLiC.IncludePaths","");
       rcling.Append(fromConfig);
+      TString extraFlags = gEnv->GetValue("ACLiC.ExtraRootclingFlags","");
+      if (!extraFlags.IsNull()) {
+        extraFlags.Prepend(" ");
+        extraFlags.Append(" ");
+        rcling.Append(extraFlags);
+      }      
    }
 
    // Create a modulemap


### PR DESCRIPTION
In order to avoid {namespace std} interfering with following include files,
when generating a dictionary file add the {using namespace std;} only after
GenerateNecessaryIncludes method is called.

Since many legacy root header files do require this global {using namespace std;}
to complete the tests, old behaviour is kept by default and the global
{using namespace std} can be avoided by adding -noGlobalUsingStd to rootcling invocation.

Allow passing ACLiC RootCling flags via .rootrc (Vassil)

This is a special patch tailored for v6-20-02